### PR TITLE
Feature: Publish and Inspect detected patterns

### DIFF
--- a/dvs_calibration/include/dvs_calibration/dvs_calibration.h
+++ b/dvs_calibration/include/dvs_calibration/dvs_calibration.h
@@ -83,6 +83,8 @@ protected:
   virtual void startCalibration() = 0;
   virtual void saveCalibration() = 0;
 
+  void publishNumDetections();
+
 
   std::vector<cv::Point3f> world_pattern_;
   virtual void addPattern(int id) = 0;

--- a/dvs_calibration/include/dvs_calibration/dvs_calibration.h
+++ b/dvs_calibration/include/dvs_calibration/dvs_calibration.h
@@ -97,9 +97,14 @@ protected:
   ros::Publisher calibration_output_pub_;
 
   ros::Publisher detected_points_left_or_single_pub_;
+  ros::Publisher detected_points_right_pub_;
   image_transport::Publisher detected_points_left_or_single_pattern_pub_;
+  image_transport::Publisher detected_points_right_pattern_pub_;
 
   void loadCalibrationParameters();
+
+  void publishAddedPattern(const int id, ros::Publisher &detected_points_pub,
+			image_transport::Publisher &detected_points_patttern_pub, std::vector<cv::Point2f> image_point_v, cv::Mat image_pattern);
 };
 
 } // namespace

--- a/dvs_calibration/include/dvs_calibration/mono_dvs_calibration.h
+++ b/dvs_calibration/include/dvs_calibration/mono_dvs_calibration.h
@@ -66,12 +66,14 @@ private:
   // ROS interface
   ros::Subscriber event_sub_;
   ros::Publisher camera_pose_pub_;
+  ros::Subscriber image_object_points_sub_;
   image_transport::Publisher visualization_pub_;
   image_transport::Publisher pattern_pub_;
   ros::ServiceClient set_camera_info_client_;
   ros::Subscriber camera_info_sub_;
   bool got_camera_info_;
   void cameraInfoCallback(const sensor_msgs::CameraInfo::ConstPtr& msg);
+  void imageObjectPointsCallback(dvs_msgs::ImageObjectPoints msg);
 };
 
 } // namespace

--- a/dvs_calibration/include/dvs_calibration/stereo_dvs_calibration.h
+++ b/dvs_calibration/include/dvs_calibration/stereo_dvs_calibration.h
@@ -72,8 +72,10 @@ private:
   ros::ServiceClient set_camera_info_left_client_, set_camera_info_right_client_;
 
   // buffer to wait for other camera
-  void addStereoPattern(std::vector<cv::Point2f> left, std::vector<cv::Point2f> right);
+  void addStereoPattern(std::vector<cv::Point2f> left, std::vector<cv::Point2f> right,
+			cv::Mat image_pattern_left, cv::Mat image_pattern_right);
   std::vector<cv::Point2f> image_point_buffer_;
+  cv::Mat image_pattern_buffer;
   bool has_left_buffer_, has_right_buffer_;
   ros::Time buffer_time_;
 

--- a/dvs_calibration/include/dvs_calibration/stereo_dvs_calibration.h
+++ b/dvs_calibration/include/dvs_calibration/stereo_dvs_calibration.h
@@ -68,6 +68,7 @@ private:
   // ROS interface
   ros::Subscriber event_left_sub_, event_right_sub_;
   ros::Subscriber camera_info_left_sub_, camera_info_right_sub_;
+  ros::Subscriber image_object_points_left_sub_, image_object_points_right_sub_;
   image_transport::Publisher visualization_left_pub_, visualization_right_pub_;
   ros::ServiceClient set_camera_info_left_client_, set_camera_info_right_client_;
 
@@ -78,6 +79,9 @@ private:
   cv::Mat image_pattern_buffer;
   bool has_left_buffer_, has_right_buffer_;
   ros::Time buffer_time_;
+
+  void imageObjectPointsLeftCallback(dvs_msgs::ImageObjectPoints msg);
+  void imageObjectPointsRightCallback(dvs_msgs::ImageObjectPoints msg);
 
   // for pose publishing
   bool got_camera_info_left_, got_camera_info_right_;

--- a/dvs_calibration/launch/intrinsic_edvs.launch
+++ b/dvs_calibration/launch/intrinsic_edvs.launch
@@ -18,7 +18,14 @@
     <remap from="events" to="/dvs/events" />
     <remap from="camera_info" to="/dvs/camera_info" />
     <remap from="set_camera_info" to="/dvs/set_camera_info" />
-
+    
+    <!-- in order to simply take all detected patterns -->
+    <!--
+    <remap from="dvs_calibration/image_object_points" to="/dvs_calibration/detected_points_left_or_single" />
+	-->
+	<!-- use output of picker tool for calibration input -->
+	<remap from="dvs_calibration/image_object_points" to="out/image_object_points" />
+	
     <param name="blinking_time_us" value="1000" />
     <param name="blinking_time_tolerance_us" value="100" />
     <!-- enough transitions to start to try to find a pattern -->
@@ -34,8 +41,14 @@
     <param name="dots_h" value="3"/>
     <!-- distance of the dots in m -->
     <param name="dot_distance" value="0.04"/>
+    
   </node>
 
   <node name="rqt_gui" pkg="rqt_gui" type="rqt_gui" args="--perspective-file $(find dvs_calibration_gui)/rqt/IntrinsicCalibration.perspective" />
 
+  <!-- pattern picker to confirm detections -->
+  <node name="pattern_picker" pkg="dvs_calibration" type="pick.py">
+	  <remap from="in/image_object_points" to="/dvs_calibration/detected_points_left_or_single" />
+	  <remap from="in/image_pattern" to="/dvs_calibration/detected_points_left_or_single_pattern" />
+  </node>
 </launch>

--- a/dvs_calibration/launch/intrinsic_edvs_usb1.launch
+++ b/dvs_calibration/launch/intrinsic_edvs_usb1.launch
@@ -18,19 +18,37 @@
     <remap from="events" to="/dvs/events" />
     <remap from="camera_info" to="/dvs/camera_info" />
     <remap from="set_camera_info" to="/dvs/set_camera_info" />
-
+    
+    <!-- in order to simply take all detected patterns -->
+    <!--
+    <remap from="dvs_calibration/image_object_points" to="/dvs_calibration/detected_points_left_or_single" />
+	-->
+	<!-- use output of picker tool for calibration input -->
+	<remap from="dvs_calibration/image_object_points" to="out/image_object_points" />
+	
     <param name="blinking_time_us" value="1000" />
     <param name="blinking_time_tolerance_us" value="100" />
-    <param name="enough_transitions_threshold" value="50" />
-    <param name="minimum_transitions_threshold" value="10" />
-    <param name="minimum_led_mass" value="3" />
+    <!-- enough transitions to start to try to find a pattern -->
+    <param name="enough_transitions_threshold" value="20" />
+    <!-- minimum transitions of a pixel in order to get used for the point detection -->
+    <param name="minimum_transitions_threshold" value="3" />
+    <!-- minimum led mass of a cluser in order to get accepted -->
+    <param name="minimum_led_mass" value="1" />
+    <!-- seconds after which the transition map will be reset-->
     <param name="pattern_search_timeout" value="1"/>
     
     <param name="dots_w" value="4"/>
     <param name="dots_h" value="3"/>
+    <!-- distance of the dots in m -->
     <param name="dot_distance" value="0.04"/>
+    
   </node>
 
   <node name="rqt_gui" pkg="rqt_gui" type="rqt_gui" args="--perspective-file $(find dvs_calibration_gui)/rqt/IntrinsicCalibration.perspective" />
 
+  <!-- pattern picker to confirm detections -->
+  <node name="pattern_picker" pkg="dvs_calibration" type="pick.py">
+	  <remap from="in/image_object_points" to="/dvs_calibration/detected_points_left_or_single" />
+	  <remap from="in/image_pattern" to="/dvs_calibration/detected_points_left_or_single_pattern" />
+  </node>
 </launch>

--- a/dvs_calibration/launch/pattern_picker_stereo.launch
+++ b/dvs_calibration/launch/pattern_picker_stereo.launch
@@ -10,5 +10,15 @@
 	  <node name="pattern_picker" pkg="dvs_calibration" type="pick.py" ns="dvs_left">
 		  <remap from="in/image_object_points" to="/dvs_calibration/detected_points_left_or_single" />
 	  </node>
+	  
 	<!-- right image -->
+	  <!-- visualization -->
+	  <node name="image_view" pkg="image_view" type="image_view" ns="dvs_right">
+		  <remap from="image" to="/dvs_calibration/detected_points_right_pattern" />
+	  </node>
+
+	  <!-- picker tool -->
+	  <node name="pattern_picker" pkg="dvs_calibration" type="pick.py" ns="dvs_right">
+		  <remap from="in/image_object_points" to="/dvs_calibration/detected_points_right" />
+	  </node>
 </launch>

--- a/dvs_calibration/launch/pattern_picker_stereo.launch
+++ b/dvs_calibration/launch/pattern_picker_stereo.launch
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+	<!-- left image -->
+	  <!-- visualization -->
+	  <node name="image_view" pkg="image_view" type="image_view" ns="dvs_left">
+		  <remap from="image" to="/dvs_calibration/detected_points_left_or_single_pattern" />
+	  </node>
+
+	  <!-- picker tool -->
+	  <node name="pattern_picker" pkg="dvs_calibration" type="pick.py" ns="dvs_left">
+		  <remap from="in/image_object_points" to="/dvs_calibration/detected_points_left_or_single" />
+	  </node>
+	<!-- right image -->
+</launch>

--- a/dvs_calibration/launch/stereo_edvs.launch
+++ b/dvs_calibration/launch/stereo_edvs.launch
@@ -22,14 +22,19 @@
     <remap from="set_camera_info_right" to="/dvs_right/set_camera_info" />
 
     <param name="blinking_time_us" value="1000" />
-    <param name="blinking_time_tolerance_us" value="200" />
-    <param name="enough_transitions_threshold" value="50" />
-    <param name="minimum_transitions_threshold" value="10" />
-    <param name="minimum_led_mass" value = "1" />
+    <param name="blinking_time_tolerance_us" value="100" />
+    <!-- enough transitions to start to try to find a pattern -->
+    <param name="enough_transitions_threshold" value="20" />
+    <!-- minimum transitions of a pixel in order to get used for the point detection -->
+    <param name="minimum_transitions_threshold" value="1" />
+    <!-- minimum led mass of a cluser in order to get accepted -->
+    <param name="minimum_led_mass" value="1" />
+    <!-- seconds after which the transition map will be reset-->
     <param name="pattern_search_timeout" value="1"/>
     
     <param name="dots_w" value="4"/>
     <param name="dots_h" value="3"/>
+    <!-- distance of the dots in m -->
     <param name="dot_distance" value="0.04"/>
   </node>
 

--- a/dvs_calibration/launch/stereo_edvs.launch
+++ b/dvs_calibration/launch/stereo_edvs.launch
@@ -20,6 +20,14 @@
     <remap from="events_right" to="/dvs_right/events" />
     <remap from="set_camera_info_left" to="/dvs_left/set_camera_info" />
     <remap from="set_camera_info_right" to="/dvs_right/set_camera_info" />
+    
+    <!-- in order to simply take all detected patterns -->
+    <!--
+    <remap from="image_object_points_left" to="/dvs_calibration/detected_points_left_or_single" />
+	-->
+	<!-- use output of picker tool for calibration input -->
+	<remap from="image_object_points_left" to="/dvs_left/out/image_object_points" />
+	<remap from="image_object_points_right" to="/dvs_right/out/image_object_points" />
 
     <param name="blinking_time_us" value="1000" />
     <param name="blinking_time_tolerance_us" value="100" />
@@ -40,4 +48,19 @@
 
   <node name="rqt_gui" pkg="rqt_gui" type="rqt_gui" args="--perspective-file $(find dvs_calibration_gui)/rqt/StereoCalibration.perspective" />
 
+
+  <!-- pattern picker to confirm detections -->
+  <node name="pattern_picker" pkg="dvs_calibration" type="pick.py" output="screen" ns="dvs_left">
+	  <remap from="in/image_object_points" to="/dvs_calibration/detected_points_left_or_single" />
+	  <remap from="in/image_pattern" to="/dvs_calibration/detected_points_left_or_single_pattern" />
+  </node>
+  
+    <!-- pattern picker to confirm detections -->
+  <node name="pattern_picker" pkg="dvs_calibration" type="pick.py" output="screen" ns="dvs_right">
+	  <remap from="in/image_object_points" to="/dvs_calibration/detected_points_right" />
+	  <remap from="in/image_pattern" to="/dvs_calibration/detected_points_right_pattern" />
+	  <param name="stereoslave" value="1" />
+	  <remap from="in/ignore" to="/dvs_left/out/ignore" />
+	  <remap from="in/take" to="/dvs_left/out/take" />
+  </node>
 </launch>

--- a/dvs_calibration/scripts/pick.py
+++ b/dvs_calibration/scripts/pick.py
@@ -7,7 +7,6 @@ import Tkinter
 import tkMessageBox
 import ImageTk
 import Image as Imagepy
-
 import cv2
 from cv_bridge import CvBridge, CvBridgeError
 from sensor_msgs.msg import Image
@@ -95,10 +94,6 @@ class Picker(object):
         
         self.lastImage = data
 
-        #if we already got some objects points, we are free to go
-        if self.lastImageOjectPoints is not False:
-            #now we have both, block until a decision is made
-            self.nowWaitForDecision()
 
     def showImage(self):
         if self.lastImage is not False:
@@ -153,6 +148,10 @@ class Picker(object):
             self.ignoreData()
             return
 
+        #we got an image, that is not too long ago
+        #so perfect, lets go
+        #and hope, they belong toegther
+        self.nowWaitForDecision()
 
         #store data
         self.lastImageOjectPoints = data

--- a/dvs_calibration/scripts/pick.py
+++ b/dvs_calibration/scripts/pick.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+import rospy
+from std_msgs.msg import String
+from dvs_msgs.msg import ImageObjectPoints
+
+import Tkinter
+import tkMessageBox
+
+
+
+class Picker(object):
+    """
+    pick messages out of topic, which should be forwarded
+
+    user will be ask every time a new message arrives, if he wants to take it
+    the user can verify, that the LED pattern was correctly detected
+    and prevent wrong calibration results caused by wrong patterns
+    """
+    def __init__(self):
+        self.imageObjectPointsPub = rospy.Publisher('out/image_object_points', ImageObjectPoints, queue_size=10)
+        self.lastImageOjectPoints = ImageObjectPoints()
+        self.lastPattern = 0
+
+    def startListener(self):
+        rospy.Subscriber("in/image_object_points", ImageObjectPoints, self.callback)
+
+        # spin() simply keeps python from exiting until this node is stopped
+        rospy.spin()
+
+    def callback(self,data):
+        self.lastImageOjectPoints = data
+        rospy.loginfo(rospy.get_caller_id() + "I heard %s", data.image_points)
+        self.scatterplot(data.image_points)
+        self.askTakeIt()
+
+    def takeData(self):
+        rospy.loginfo("take data and publish it")
+        self.imageObjectPointsPub.publish(self.lastImageOjectPoints)
+
+    def askTakeIt(self):
+        answer = tkMessageBox.askyesno('Verify Pattern', 'Do you want to use this detected pattern for calibration?')
+        if answer:
+            self.takeData()
+            #tkMessageBox.showinfo('No', 'Quit has been cancelled')
+
+    def scatterplot(self,points):
+        import matplotlib.pyplot as plt
+        import random
+        import numpy as np
+
+        #in images ---x-->
+        # and y downwards
+        #     |
+        #    \/
+
+        x = []
+        y = []
+        for i in points:
+            x.append(i.x)
+            y.append(128-i.y)
+
+        plt.axis((0,128,0,128))
+
+        #get random color between 0 and 1
+        #and use it for all points
+        #TODO: not working yet
+        colors = (100 * random.random()) * np.ones(len(x))
+
+        print("colors are",colors)
+        plt.scatter(x, y, c=colors, alpha=0.5)
+        
+        #make interactive plot, so it is nonblocking
+        plt.ion()
+
+        #show data witout clearing image
+        #so we add up the examples
+        plt.show()
+
+if __name__ == '__main__':
+    try:
+        #talker()
+        rospy.init_node('picker', anonymous=True)
+        p = Picker()
+        p.startListener()
+    except rospy.ROSInterruptException:
+        pass

--- a/dvs_calibration/scripts/pick.py
+++ b/dvs_calibration/scripts/pick.py
@@ -137,6 +137,11 @@ class Picker(object):
             rospy.loginfo(rospy.get_caller_id() + "ignore points (waiting for decision)")
             return
 
+        if self.lastImage is False:
+            rospy.loginfo(rospy.get_caller_id() + "did not yet receive an image")
+            return
+
+
         #check if time difference to image is too large
         #image should always come before points
         me = data.header.stamp
@@ -163,14 +168,17 @@ class Picker(object):
     def nowWaitForDecision(self):
         self.waitingForDecision = True
         self.labelWaitStr.set('waiting for decision')
-        self.addButton.config(state="normal")
-        self.ignoreButton.config(state="normal")
+
+        if self.isStereoSlave is not True:
+            self.addButton.config(state="normal")
+            self.ignoreButton.config(state="normal")
 
     def stopWaitingForDecision(self):
         self.waitingForDecision = False
 
-        self.addButton.config(state="disabled")
-        self.ignoreButton.config(state="disabled")
+        if self.isStereoSlave is not True:
+            self.addButton.config(state="disabled")
+            self.ignoreButton.config(state="disabled")
 
         #reset to false, so wait until we got object points
         #followed by an image

--- a/dvs_calibration/scripts/pick.py
+++ b/dvs_calibration/scripts/pick.py
@@ -5,6 +5,8 @@ from dvs_msgs.msg import ImageObjectPoints
 
 import Tkinter
 import tkMessageBox
+import ImageTk
+import Image as Imagepy
 
 import cv2
 from cv_bridge import CvBridge, CvBridgeError
@@ -20,13 +22,41 @@ class Picker(object):
     and prevent wrong calibration results caused by wrong patterns
     """
     def __init__(self):
-        self.imageObjectPointsPub = rospy.Publisher('out/image_object_points', ImageObjectPoints, queue_size=10)
-        self.lastImageOjectPoints = ImageObjectPoints()
+        self.imageObjectPointsPub = rospy.Publisher('out/image_object_points', ImageObjectPoints, queue_size=1)
+        self.lastImageOjectPoints = False
         self.lastImage = False
+
+        self.ignorePub = rospy.Publisher('out/ignore', String, queue_size=1)
+        self.takePub = rospy.Publisher('out/take', String, queue_size=1)
+
+        #some default size
+        self.lastImageSize = (512,512)
 
         self.title = rospy.get_namespace() + ' - ' + rospy.get_name()
 
-        cv2.namedWindow(self.title, 1)
+        self.isStereoSlave = bool(rospy.get_param('~stereoslave',False))
+        rospy.loginfo("am i stereo? %d",self.isStereoSlave)
+
+        self.root = Tkinter.Tk()
+
+        self.root.wm_title(self.title)
+        self.label = Tkinter.Label(self.root, text='last pattern')
+        self.label.pack()
+        self.imgtk = None
+
+        self.labelWaitStr = Tkinter.StringVar()
+        self.labelWait = Tkinter.Label(self.root, textvariable=self.labelWaitStr)
+        self.labelWait.pack()
+
+        if self.isStereoSlave is not True:
+            self.addButton = Tkinter.Button(self.root, text='Add Pattern', command=self.takeData)
+            self.addButton.pack()
+
+            self.ignoreButton = Tkinter.Button(self.root, text='Ignore Pattern', command=self.ignoreData)
+            self.ignoreButton.pack()
+
+        self.clearImage()
+        self.stopWaitingForDecision()
 
     def startListener(self):
         self.points_sub = rospy.Subscriber("in/image_object_points", \
@@ -36,36 +66,143 @@ class Picker(object):
         self.image_sub = rospy.Subscriber("in/image_pattern",Image,self.imageCallback)
 
 
+        self.ignoreSub = rospy.Subscriber("in/ignore",String,self.ignoreCallback)
+        self.takeSub = rospy.Subscriber("in/take",String,self.takeCallback)
+
+
+    def ignoreCallback(self,msg):
+        """
+        in stereo setup, reset callback to sync both windows
+        """
+        rospy.loginfo("got reset callback on topic")
+
+        #reset everything
+        self.ignoreData()
+
+    def takeCallback(self,msg):
+        rospy.loginfo("got take callback on topic")
+
+        #reset everything
+        self.takeData()
+
     def imageCallback(self,data):
         rospy.loginfo(rospy.get_caller_id() + "I got an image")
-        try:
-            self.lastImage = self.bridge.imgmsg_to_cv2(data, "bgr8")
-        except CvBridgeError as e:
-            print(e)
+
+
+        if self.waitingForDecision is True:
+            rospy.loginfo(rospy.get_caller_id() + "ignore image (waiting for decision)")
+            return
+        
+        self.lastImage = data
+
+        #if we already got some objects points, we are free to go
+        if self.lastImageOjectPoints is not False:
+            #now we have both, block until a decision is made
+            self.nowWaitForDecision()
+
+    def showImage(self):
+        if self.lastImage is not False:
+            try:
+                image_bgr8 = self.bridge.imgmsg_to_cv2(self.lastImage, "bgr8")
+                self.lastImageSize = image_bgr8.shape[:2]
+
+            except CvBridgeError as e:
+                print(e)
+
+            cv2image = cv2.cvtColor(image_bgr8, cv2.COLOR_BGR2RGBA)
+
+            im = Imagepy.fromarray(cv2image)
+            #im = Imagepy.fromstring('RGB', cv2.GetSize(self.lastImage), self.lastImage.tostring())
+            # Convert the Image object into a TkPhoto object
+            self.imgtk = ImageTk.PhotoImage(image=im) 
+
+            # Put it in the display window
+            #Tkinter.Label(root, image=imgtk).pack() 
+            self.label.config(image=self.imgtk)
+
+            rospy.sleep(0.05)
+
+    def clearImage(self):
+        #create new image of size x
+        im = Imagepy.new('RGB', self.lastImageSize, 'black')
+
+        # Convert the Image object into a TkPhoto object
+        self.imgtk = ImageTk.PhotoImage(image=im) 
+
+        #show image
+        self.label.config(image=self.imgtk)
+
+        rospy.sleep(0.05)
 
 
     def pointsCallback(self,data):
+        rospy.loginfo(rospy.get_caller_id() + "got points callback")
+
+        if self.waitingForDecision is True:
+            rospy.loginfo(rospy.get_caller_id() + "ignore points (waiting for decision)")
+            return
+
+        #check if time difference to image is too large
+        #image should always come before points
+        me = data.header.stamp
+        diff = me - self.lastImage.header.stamp
+        #usually about 0.001537061
+        maxDiff = rospy.Duration.from_sec(0.01)
+        if diff > maxDiff:
+            print("time difference was to much, do not take it", diff.to_sec())
+            self.ignoreData()
+            return
+
+
+        #store data
         self.lastImageOjectPoints = data
-        rospy.loginfo(rospy.get_caller_id() + "I heard %s", data.image_points)
+
         #self.scatterplot(data.image_points)
 
-        #show last image
-        cv2.imshow(self.title, self.lastImage)
-        #do not wait at all
-        cv2.waitKey(1)
+        self.showImage()
 
-        #ask if we want to take that pattern
-        self.askTakeIt()
+    def nowWaitForDecision(self):
+        self.waitingForDecision = True
+        self.labelWaitStr.set('waiting for decision')
+        self.addButton.config(state="normal")
+        self.ignoreButton.config(state="normal")
+
+    def stopWaitingForDecision(self):
+        self.waitingForDecision = False
+
+        self.addButton.config(state="disabled")
+        self.ignoreButton.config(state="disabled")
+
+        #reset to false, so wait until we got object points
+        #followed by an image
+        #then wait for decision
+        self.lastImageOjectPoints = False
+        self.labelWaitStr.set('waiting for pattern')
+
+    def ignoreData(self):
+        rospy.loginfo("ignore data")
+
+        msg = String('take')
+        self.ignorePub.publish(msg)
+
+        self.clearImage()
+        self.stopWaitingForDecision()
+
 
     def takeData(self):
+        if self.waitingForDecision is False:
+            rospy.loginfo("do not take data, not complete")
+            return
+
         rospy.loginfo("take data and publish it")
+
         self.imageObjectPointsPub.publish(self.lastImageOjectPoints)
 
-    def askTakeIt(self):
-        answer = tkMessageBox.askyesno(self.title, 'Do you want to use this detected pattern for calibration?')
-        if answer:
-            self.takeData()
-            #tkMessageBox.showinfo('No', 'Quit has been cancelled')
+        msg = String('take')
+        self.takePub.publish(msg)
+
+        self.clearImage()
+        self.stopWaitingForDecision()
 
     def scatterplot(self,points):
         import matplotlib.pyplot as plt
@@ -100,18 +237,21 @@ class Picker(object):
         #so we add up the examples
         plt.show()
 
+    def run(self):
+        #start main loop of tkinter
+        self.root.mainloop()
+
 def main():
     rospy.init_node('picker', anonymous=True)
     p = Picker()
     p.startListener()
     try:
         # spin() simply keeps python from exiting until this node is stopped
-        rospy.spin()
+        p.run()
     except KeyboardInterrupt:
         print("shutting down")
     except rospy.ROSInterruptException:
         pass
-    cv2.destroyAllWindows()
 
 if __name__ == '__main__':
     main()

--- a/dvs_calibration/src/mono_dvs_calibration.cpp
+++ b/dvs_calibration/src/mono_dvs_calibration.cpp
@@ -35,6 +35,9 @@ MonoDvsCalibration::MonoDvsCalibration()
   camera_info_sub_ = nh_.subscribe("camera_info", 1, &MonoDvsCalibration::cameraInfoCallback, this);
   got_camera_info_ = false;
   camera_pose_pub_ = nh_.advertise<geometry_msgs::PoseStamped>("dvs_calibration/pose", 1);
+
+  image_object_points_sub_ = nh_.subscribe("dvs_calibration/image_object_points", 1,
+		  	  	  	  	  	  	  &MonoDvsCalibration::imageObjectPointsCallback, this);
 }
 
 void MonoDvsCalibration::calibrate()
@@ -122,11 +125,6 @@ void MonoDvsCalibration::saveCalibration()
 
 void MonoDvsCalibration::addPattern(int id)
 {
-  // add detection
-  image_points_.push_back(transition_maps_[id].pattern);
-  object_points_.push_back(world_pattern_);
-  num_detections_++;
-
   publishAddedPattern(id, detected_points_left_or_single_pub_,
 		  detected_points_left_or_single_pattern_pub_, transition_maps_[id].pattern,
 		  transition_maps_[id].get_visualization_image());
@@ -162,6 +160,43 @@ void MonoDvsCalibration::addPattern(int id)
 
     camera_pose_pub_.publish(pose_msg);
   }
+}
+
+void MonoDvsCalibration::imageObjectPointsCallback(dvs_msgs::ImageObjectPoints msg)
+{
+  ROS_INFO("imageObjectPointsCallback");
+
+  //convert message to point2f vector
+  std::vector<cv::Point2f> left;
+
+  cv::Point2f image_point;
+  for (dvs_msgs::Point2f pp : msg.image_points) {
+	  image_point.x = pp.x;
+	  image_point.y = pp.y;
+	  left.push_back(image_point);
+  }
+
+  // add detection
+  image_points_.push_back(left);
+
+  //convert message to point3f vector
+  std::vector<cv::Point3f> object_points;
+
+  cv::Point3f object_point;
+  for (dvs_msgs::Point3f pp : msg.object_points) {
+	  object_point.x = pp.x;
+	  object_point.y = pp.y;
+	  object_point.z = pp.z;
+	  object_points.push_back(object_point);
+  }
+
+  // add object points only for left callback
+  // are the same for the right callback
+  object_points_.push_back(object_points);
+  num_detections_++;
+
+  //update publisher
+  publishNumDetections();
 }
 
 void MonoDvsCalibration::cameraInfoCallback(const sensor_msgs::CameraInfo::ConstPtr& msg)

--- a/dvs_calibration/src/mono_dvs_calibration.cpp
+++ b/dvs_calibration/src/mono_dvs_calibration.cpp
@@ -119,6 +119,7 @@ void MonoDvsCalibration::saveCalibration()
     ROS_ERROR("Error while saving calibration");
 }
 
+
 void MonoDvsCalibration::addPattern(int id)
 {
   // add detection
@@ -126,34 +127,9 @@ void MonoDvsCalibration::addPattern(int id)
   object_points_.push_back(world_pattern_);
   num_detections_++;
 
-  //publish detection points
-  //can be used for rosbag recordings and inspect the detected points or
-  //to store them with rosbag and potentially play them back later, e.g. for calibration again
-  dvs_msgs::ImageObjectPointsPtr image_object_points_msg(new dvs_msgs::ImageObjectPoints());
-
-  dvs_msgs::Point2f image_point;
-  for (cv::Point2f pp : transition_maps_[id].pattern) {
-	  image_point.x = pp.x;
-	  image_point.y = pp.y;
-	  image_object_points_msg->image_points.push_back(image_point);
-  }
-  dvs_msgs::Point3f image_point3;
-    for (cv::Point3f pp : world_pattern_) {
-  	  image_point3.x = pp.x;
-  	  image_point3.y = pp.y;
-  	  image_point3.z = pp.z;
-  	  image_object_points_msg->object_points.push_back(image_point3);
-    }
-  detected_points_left_or_single_pub_.publish(image_object_points_msg);
-
-  //publish detection transition image for the detected points
-  cv_bridge::CvImage cv_image;
-  cv_image.encoding = "bgr8";
-  cv_image.image = transition_maps_[id].get_visualization_image().clone();
-
-  detected_points_left_or_single_pattern_pub_.publish(cv_image.toImageMsg());
-
-
+  publishAddedPattern(id, detected_points_left_or_single_pub_,
+		  detected_points_left_or_single_pattern_pub_, transition_maps_[id].pattern,
+		  transition_maps_[id].get_visualization_image());
 
   // compute and publish camera pose if camera is calibrated
   if (got_camera_info_)

--- a/dvs_calibration/src/stereo_dvs_calibration.cpp
+++ b/dvs_calibration/src/stereo_dvs_calibration.cpp
@@ -187,7 +187,8 @@ void StereoDvsCalibration::addPattern(int id)
       ROS_INFO("pattern from left camera");
       if (has_right_buffer_) {
         if (ros::Time::now() - buffer_time_ < stereo_max_buffer_time_difference) {
-          addStereoPattern(transition_maps_[left_camera_id].pattern, image_point_buffer_);
+          addStereoPattern(transition_maps_[left_camera_id].pattern, image_point_buffer_,
+        		  transition_maps_[left_camera_id].get_visualization_image(), image_pattern_buffer);
           ROS_INFO("Added detection!");
         }
         else {
@@ -198,6 +199,7 @@ void StereoDvsCalibration::addPattern(int id)
         // add to buffer
         buffer_time_ = ros::Time::now();
         image_point_buffer_ = transition_maps_[left_camera_id].pattern;
+        image_pattern_buffer = transition_maps_[left_camera_id].get_visualization_image();
         has_left_buffer_ = true;
       }
     }
@@ -205,7 +207,8 @@ void StereoDvsCalibration::addPattern(int id)
       ROS_INFO("pattern from right camera");
       if (has_left_buffer_) {
         if (ros::Time::now() - buffer_time_ < stereo_max_buffer_time_difference) {
-          addStereoPattern(image_point_buffer_, transition_maps_[right_camera_id].pattern);
+          addStereoPattern(image_point_buffer_, transition_maps_[right_camera_id].pattern,
+        		  image_pattern_buffer, transition_maps_[right_camera_id].get_visualization_image());
           ROS_INFO("Added detection!");
         }
         else {
@@ -216,6 +219,7 @@ void StereoDvsCalibration::addPattern(int id)
         // add to buffer
         buffer_time_ = ros::Time::now();
         image_point_buffer_ = transition_maps_[right_camera_id].pattern;
+        image_pattern_buffer = transition_maps_[right_camera_id].get_visualization_image();
         has_right_buffer_ = true;
       }
     }
@@ -225,13 +229,19 @@ void StereoDvsCalibration::addPattern(int id)
   }
 }
 
-void StereoDvsCalibration::addStereoPattern(std::vector<cv::Point2f> left, std::vector<cv::Point2f> right)
+void StereoDvsCalibration::addStereoPattern(std::vector<cv::Point2f> left, std::vector<cv::Point2f> right,
+		cv::Mat image_pattern_left, cv::Mat image_pattern_right)
 {
   // add detection
   image_points_left_.push_back(left);
   image_points_right_.push_back(right);
   object_points_.push_back(world_pattern_);
   num_detections_++;
+
+  publishAddedPattern(left_camera_id, detected_points_left_or_single_pub_,
+		  detected_points_left_or_single_pattern_pub_, left, image_pattern_left);
+  publishAddedPattern(right_camera_id, detected_points_right_pub_,
+		  detected_points_right_pattern_pub_, right, image_pattern_right);
 }
 
 void StereoDvsCalibration::updateVisualization(int id)

--- a/dvs_calibration/src/transition_map.cpp
+++ b/dvs_calibration/src/transition_map.cpp
@@ -111,7 +111,7 @@ cv::Mat TransitionMap::get_visualization_image()
   if (has_pattern())
   {
     // Resize image to draw sharper/sub-pixel ChessboardCorners
-    const int upscale_factor = 4;
+    const int upscale_factor = 3;
     cv::Mat upscale_image;
     cv::Size upscale_size = cv::Size(image.rows * upscale_factor, image.cols * upscale_factor);
     cv::resize(image, upscale_image, upscale_size, 0, 0, cv::INTER_NEAREST);

--- a/edvs_driver/include/edvs_driver/edvs_driver.h
+++ b/edvs_driver/include/edvs_driver/edvs_driver.h
@@ -75,6 +75,8 @@ private:
 
   uint64_t integratedTimeSinceReset; // sum of time_deltas in us
 
+  uint32_t last_timestamp;
+
   class Parameter {
   public:
     Parameter(uint32_t min = 0, uint32_t max = 0, uint32_t value = 0) :

--- a/edvs_driver/src/edvs_driver.cpp
+++ b/edvs_driver/src/edvs_driver.cpp
@@ -58,7 +58,7 @@ EDVS_Driver::EDVS_Driver(std::string edvs_port, bool master) {
 
 	  capture = new Edvs::EventCapture(*device, cbf);
   } catch (std::runtime_error &ex) {
-    ROS_ERROR(ex.what());
+    ROS_ERROR("edvs_driver error %s",ex.what());
     device_mutex.unlock();
     device = nullptr; // Not sure this is necessary. Also, do we have a memory leak if the exception comes from eventcapture?
     return;

--- a/utils/plot.py
+++ b/utils/plot.py
@@ -1,0 +1,87 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+import matplotlib.cm as cm
+
+import csv
+import sys
+
+class loadTopicData(object):
+
+    def loadCsvFile(self,filename):
+        print("read file ",filename)
+        data_iter = csv.reader(open(filename), delimiter=",")
+        data = [row for row in data_iter]
+        return data
+
+    def loadFiles(self,files):
+        dataset = []
+        for name in files:
+            dataset.append(self.loadCsvFile(name))
+
+        return dataset
+
+    def parseRow(self,row):
+        points = []
+        #offset, how many columns to ignore
+        offset = 3
+        for i in range(1,24,2):
+            #print("row is",row)
+            x = float(row[offset+i])
+            y = float(row[offset + i + 1])
+            #print(x,y)
+            points.append((x,y))
+
+        return points 
+
+def initFig():
+    #clear figure
+    plt.clf()
+    plt.xlabel("x")
+    plt.ylabel("y")
+    plt.axis((0,128,0,128))
+
+def plotPattern(data,index):
+    loader = loadTopicData()
+    points = loader.parseRow(data[index])
+    colors = cm.rainbow(np.linspace(0, 1, 20))
+    for p in points:
+        plt.scatter(p[0],128.0-p[1],color=colors[index % 20], alpha=0.5)
+
+
+def main():
+    loader = loadTopicData()
+
+    files = sys.argv[1:]
+    dataset = loader.loadFiles(files)
+
+    plt.figure('test')
+
+
+    #ignore header row
+    first = True 
+    line = 1
+    for row in dataset[0]:
+        if first is True:
+            first = False
+            continue 
+
+        initFig()
+        for i in range(0,len(dataset)):
+            print("dataset is",i)
+            plotPattern(dataset[i],line)
+
+
+        #plot file2
+
+        line += 1
+        plt.ion()
+        plt.show()
+        raw_input("Press Enter to continue...")
+
+
+
+    plt.show()
+
+if __name__ == '__main__':
+    main()

--- a/utils/plot3d.py
+++ b/utils/plot3d.py
@@ -1,0 +1,144 @@
+import yaml
+import sys
+import cv2
+import numpy as np
+import pprint
+
+
+def tupleToXYArray(points):
+    arr = [[],[]]
+    for p in points:
+        arr[0].append(p[0])
+        arr[1].append(p[1])
+
+    return arr
+
+
+def getCorrespondingPoints(loader,dataset):
+    #skip first line
+    p1_all = []
+    p2_all = []
+    for index,row in enumerate(dataset[0][1:]):
+        points1 = loader.parseRow(row)
+
+        #+1 because we ignore firt line
+        points2 = loader.parseRow(dataset[1][index+1])
+
+        p1_all += points1
+        p2_all += points2
+
+    p1_all = tupleToXYArray(p1_all)
+    p2_all = tupleToXYArray(p2_all)
+
+    return (np.array(p1_all), np.array(p2_all))
+
+
+
+
+def loadPoints(file1,file2):
+    from plot import loadTopicData
+
+    loader = loadTopicData()
+
+    files = [file1, file2]
+
+    dataset = loader.loadFiles(files)
+
+    points = getCorrespondingPoints(loader,dataset)
+
+    return points
+
+
+
+
+def loadProjectionPatrix(filename):
+    f = open(filename)
+    dataMap = yaml.safe_load(f)
+    f.close()
+
+    data = dataMap['projection_matrix']['data']
+    #create numpy array
+    rows = dataMap['projection_matrix']['rows']
+    cols = dataMap['projection_matrix']['cols']
+    p = np.array(data).reshape((rows,cols))
+
+    return p
+
+
+if len(sys.argv) != 5:
+    print("Error: not enough input arguments!\n")
+    print("usage: plot3d.py left-yaml-file right-yaml-file points-left points-right")
+    print("\nexample:\n\tplot3d.py ../ttyUSB0.yaml ../ttyUSB1.yaml points-left.csv points-right.csv")
+    exit()
+
+points1,points2 = loadPoints(sys.argv[3],sys.argv[4])
+
+#projection matrix of camera 1
+P1 = loadProjectionPatrix(sys.argv[1])
+P2 = loadProjectionPatrix(sys.argv[2])
+
+#P1[0][3] = -0.12
+print("P1",P1)
+print("P2",P2)
+
+
+"""
+#input points 1
+rows = 2
+#number of points
+cols = 2
+points1 = np.array([117.627388,105.089256287, 128-77.5111198425, 128-77.06656646729999]).reshape((rows,cols))
+#input points 2
+points2 = np.array([77.6499099731,63.3031005859, 128-77.766292572, 128-77.45426940920001]).reshape((rows,cols))
+"""
+
+print("2d points",points1,points2)
+points3d = cv2.triangulatePoints(P1,P2,points1,points2)
+
+print("3d points",points3d)
+
+#homogenous coordinates: x,y,z,w
+#make it homogenous
+points3d /= points3d[3]
+
+#normalized
+print("3d points",points3d)
+
+
+
+#plot in 3d
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D
+fig = plt.figure()
+ax = fig.add_subplot(111, projection='3d')
+
+#set bounding box and equal scaling on all axes
+ax.set_aspect('equal')
+
+dst = 0.4
+ax.set_xlim(points3d[0].mean()-dst,points3d[0].mean()+dst)
+ax.set_ylim(points3d[1].mean()-dst,points3d[1].mean()+dst)
+ax.set_zlim(points3d[2].mean()-dst,points3d[2].mean()+dst)
+
+
+
+import matplotlib.cm as cm
+colors = cm.rainbow(np.linspace(0, 1, 20))
+
+#for every 12 points (we always get 12 points at once, because this is our led pattern)
+led_points = 12
+for a in range(0,len(points3d[0])/led_points):
+    ax.scatter(points3d[0][a*12:(a+1)*12],points3d[1][a*12:(a+1)*12],points3d[2][a*12:(a+1)*12],color=colors[(2*a)%20], alpha=0.5)
+
+#first camera
+baseline = P1[0][3]/(-P1[0][0])
+print("baseline is ",baseline)
+ax.scatter(baseline,0,0,color='red')
+
+#second camera
+baseline = P2[0][3]/(-P2[0][0])
+print("baseline is ",baseline)
+ax.scatter(baseline,0,0,color='red')
+
+plt.show()
+


### PR DESCRIPTION
Problem:
Sometimes, wrong patterns get detected. These wrong pattern have a bad influence on the calibration. 

Solution:
Inspect detected patterns before using them for calibration

How?
The detected points and the transition pattern will get published. Then, a new tool helps to pick the patterns. It asks the user, whether to take it or not (yes/no). If the user takes it, it will get published on a new topic, where the calibration process is subscribed to.

Does it break the existing way?
Yes - because the topic names are now different. 

Can it still work without the manual pattern picker tool?
In order to work like before, the calibration process has to subscribe to its own published detected patterns. This can be achieved by remapping the topics in a launch file.

Utilities:
In order to further investigate the problems, one can use rosbag and python scripts to plot the detected points.
